### PR TITLE
Fix chalk import

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,19 +1,15 @@
-import {Readable, Stream} from "stream";
-
-const fetch = require('node-fetch');
-const vosk = require('vosk')
-const fs = require("fs");
-const SAMPLE_RATE = 44100
-const Speaker = require('speaker');
-const googleTTS = require('google-tts-api');
-const sox = require('sox-stream')
-require('dotenv').config();
-const getMP3Duration = require('get-mp3-duration')
-let chalk;
-import('chalk').then((value) => {
-    chalk = value.default;
-})
-const mic = require('mic');
+import { Readable, Stream } from "stream";
+import fetch from "node-fetch";
+import vosk from "vosk";
+import fs from "fs";
+const SAMPLE_RATE = 44100;
+import Speaker from "speaker";
+import googleTTS from "google-tts-api";
+import sox from "sox-stream";
+import "dotenv/config";
+import getMP3Duration from "get-mp3-duration";
+import chalk from "chalk";
+import mic from "mic";
 
 const MODEL_PATH = "./model/vosk-model-en-us-0.22"; const LANGUAGE = "en"
 //const MODEL_PATH = "./model/vosk-model-small-en-us-0.15"; const LANGUAGE = "en"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,10 @@
     "lib": ["ES6"],
     "module": "Node16",
     "target": "ES6",
-    "sourceMap": true
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
## Summary
- use ESM imports for chalk and other modules
- relax tsconfig options

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx tsc --noEmit` *(fails to compile due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6847994c0938832e866fcefc34493bce